### PR TITLE
Fix buffer out of range crash

### DIFF
--- a/device/queueconstants_windows.go
+++ b/device/queueconstants_windows.go
@@ -10,6 +10,6 @@ const (
 	QueueOutboundSize          = 1024
 	QueueInboundSize           = 1024
 	QueueHandshakeSize         = 1024
-	MaxSegmentSize             = 2048 - 32 // largest possible UDP datagram
-	PreallocatedBuffersPerPool = 0         // Disable and allow for infinite memory growth
+	MaxSegmentSize             = 65535 // Match with WINTUN_MAX_IP_PACKET_SIZE macro definition
+	PreallocatedBuffersPerPool = 0     // Disable and allow for infinite memory growth
 )


### PR DESCRIPTION
The wintun driver can provide larger packages than the buffer size of the reader part.

In the wintun driver the max pkg size has been defined in the WINTUN_MAX_IP_PACKET_SIZE 
marcro. It was not match with the buffer size at the Go part. After the Go code read package 
from the TUN device, it tried to read from the buffer bigger range of the buffer than the original, 
hardcoded capacity.
```
panic: runtime error: slice bounds out of range [:11339] with capacity 2016

goroutine 102 [running]:
golang.zx2c4.com/wireguard/device.(*Device).RoutineReadFromTUN(0xc0000c6a00)
        /home/runner/go/pkg/mod/github.com/netbirdio/wireguard-go@v0.0.0-20230426151838-5c7986a94d53/device/send.go:250 +0xa47
```