### PR TITLE
Add custom ReceiverCreator

### DIFF
--- a/conn/receiver_creator.go
+++ b/conn/receiver_creator.go
@@ -1,0 +1,12 @@
+package conn
+
+import (
+	"net"
+	"sync"
+
+	"golang.org/x/net/ipv4"
+)
+
+type ReceiverCreator interface {
+	CreateIPv4ReceiverFn(msgPool *sync.Pool, pc *ipv4.PacketConn, conn *net.UDPConn) ReceiveFunc
+}

--- a/conn/sticky_default.go
+++ b/conn/sticky_default.go
@@ -25,9 +25,9 @@ func (e *StdNetEndpoint) SrcToString() string {
 // {get,set}srcControl feature set, but use alternatively named flags and need
 // ports and require testing.
 
-// getSrcFromControl parses the control for PKTINFO and if found updates ep with
+// GetSrcFromControl parses the control for PKTINFO and if found updates ep with
 // the source information found.
-func getSrcFromControl(control []byte, ep *StdNetEndpoint) {
+func GetSrcFromControl(control []byte, ep *StdNetEndpoint) {
 }
 
 // setSrcControl parses the control for PKTINFO and if found updates ep with
@@ -35,8 +35,8 @@ func getSrcFromControl(control []byte, ep *StdNetEndpoint) {
 func setSrcControl(control *[]byte, ep *StdNetEndpoint) {
 }
 
-// stickyControlSize returns the recommended buffer size for pooling sticky
+// StickyControlSize returns the recommended buffer size for pooling sticky
 // offloading control data.
-const stickyControlSize = 0
+const StickyControlSize = 0
 
 const StdNetSupportsStickySockets = false

--- a/conn/sticky_linux.go
+++ b/conn/sticky_linux.go
@@ -45,9 +45,9 @@ func (e *StdNetEndpoint) SrcToString() string {
 	return e.SrcIP().String()
 }
 
-// getSrcFromControl parses the control for PKTINFO and if found updates ep with
+// GetSrcFromControl parses the control for PKTINFO and if found updates ep with
 // the source information found.
-func getSrcFromControl(control []byte, ep *StdNetEndpoint) {
+func GetSrcFromControl(control []byte, ep *StdNetEndpoint) {
 	ep.ClearSrc()
 
 	var (
@@ -105,8 +105,8 @@ func setSrcControl(control *[]byte, ep *StdNetEndpoint) {
 	*control = append(*control, ep.src...)
 }
 
-// stickyControlSize returns the recommended buffer size for pooling sticky
+// StickyControlSize returns the recommended buffer size for pooling sticky
 // offloading control data.
-var stickyControlSize = unix.CmsgSpace(unix.SizeofInet6Pktinfo)
+var StickyControlSize = unix.CmsgSpace(unix.SizeofInet6Pktinfo)
 
 const StdNetSupportsStickySockets = true

--- a/conn/sticky_linux_test.go
+++ b/conn/sticky_linux_test.go
@@ -60,7 +60,7 @@ func Test_setSrcControl(t *testing.T) {
 		}
 		setSrc(ep, netip.MustParseAddr("127.0.0.1"), 5)
 
-		control := make([]byte, stickyControlSize)
+		control := make([]byte, StickyControlSize)
 
 		setSrcControl(&control, ep)
 
@@ -89,7 +89,7 @@ func Test_setSrcControl(t *testing.T) {
 		}
 		setSrc(ep, netip.MustParseAddr("::1"), 5)
 
-		control := make([]byte, stickyControlSize)
+		control := make([]byte, StickyControlSize)
 
 		setSrcControl(&control, ep)
 
@@ -113,7 +113,7 @@ func Test_setSrcControl(t *testing.T) {
 	})
 
 	t.Run("ClearOnNoSrc", func(t *testing.T) {
-		control := make([]byte, stickyControlSize)
+		control := make([]byte, StickyControlSize)
 		hdr := (*unix.Cmsghdr)(unsafe.Pointer(&control[0]))
 		hdr.Level = 1
 		hdr.Type = 2
@@ -129,7 +129,7 @@ func Test_setSrcControl(t *testing.T) {
 
 func Test_getSrcFromControl(t *testing.T) {
 	t.Run("IPv4", func(t *testing.T) {
-		control := make([]byte, stickyControlSize)
+		control := make([]byte, StickyControlSize)
 		hdr := (*unix.Cmsghdr)(unsafe.Pointer(&control[0]))
 		hdr.Level = unix.IPPROTO_IP
 		hdr.Type = unix.IP_PKTINFO
@@ -139,7 +139,7 @@ func Test_getSrcFromControl(t *testing.T) {
 		info.Ifindex = 5
 
 		ep := &StdNetEndpoint{}
-		getSrcFromControl(control, ep)
+		GetSrcFromControl(control, ep)
 
 		if ep.SrcIP() != netip.MustParseAddr("127.0.0.1") {
 			t.Errorf("unexpected address: %v", ep.SrcIP())
@@ -149,7 +149,7 @@ func Test_getSrcFromControl(t *testing.T) {
 		}
 	})
 	t.Run("IPv6", func(t *testing.T) {
-		control := make([]byte, stickyControlSize)
+		control := make([]byte, StickyControlSize)
 		hdr := (*unix.Cmsghdr)(unsafe.Pointer(&control[0]))
 		hdr.Level = unix.IPPROTO_IPV6
 		hdr.Type = unix.IPV6_PKTINFO
@@ -159,7 +159,7 @@ func Test_getSrcFromControl(t *testing.T) {
 		info.Ifindex = 5
 
 		ep := &StdNetEndpoint{}
-		getSrcFromControl(control, ep)
+		GetSrcFromControl(control, ep)
 
 		if ep.SrcIP() != netip.MustParseAddr("::1") {
 			t.Errorf("unexpected address: %v", ep.SrcIP())
@@ -173,7 +173,7 @@ func Test_getSrcFromControl(t *testing.T) {
 		ep := &StdNetEndpoint{}
 		setSrc(ep, netip.MustParseAddr("::1"), 5)
 
-		getSrcFromControl(control, ep)
+		GetSrcFromControl(control, ep)
 		if ep.SrcIP().IsValid() {
 			t.Errorf("unexpected address: %v", ep.SrcIP())
 		}
@@ -200,7 +200,7 @@ func Test_getSrcFromControl(t *testing.T) {
 		combined = append(combined, control...)
 
 		ep := &StdNetEndpoint{}
-		getSrcFromControl(combined, ep)
+		GetSrcFromControl(combined, ep)
 
 		if ep.SrcIP() != netip.MustParseAddr("127.0.0.1") {
 			t.Errorf("unexpected address: %v", ep.SrcIP())

--- a/device/queueconstants_windows.go
+++ b/device/queueconstants_windows.go
@@ -10,6 +10,6 @@ const (
 	QueueOutboundSize          = 1024
 	QueueInboundSize           = 1024
 	QueueHandshakeSize         = 1024
-	MaxSegmentSize             = 2048 - 32 // largest possible UDP datagram
-	PreallocatedBuffersPerPool = 0         // Disable and allow for infinite memory growth
+	MaxSegmentSize             = 65535 // Match with WINTUN_MAX_IP_PACKET_SIZE macro definition
+	PreallocatedBuffersPerPool = 0     // Disable and allow for infinite memory growth
 )


### PR DESCRIPTION
Export the ipv4 receive function. It grants the option for custom logic in third-party algorithms.

**Fix buffer out of range crash**
The wintun driver can provide larger packages
than the buffer size of the reader part. (Check queue constants_windows.go)