### PR TITLE
Send immediate handshake when endpoint address changes

### DIFF
--- a/device/send.go
+++ b/device/send.go
@@ -139,6 +139,16 @@ func (peer *Peer) SendHandshakeInitiation(isRetry bool) error {
 	return err
 }
 
+// SendImmediateHandshakeInitiation resets the RekeyTimeout throttle and sends a
+// handshake initiation right away. Used when the endpoint just changed.
+func (peer *Peer) SendImmediateHandshakeInitiation() error {
+	peer.handshake.mutex.Lock()
+	peer.handshake.lastSentHandshake = time.Now().Add(-(RekeyTimeout + time.Second))
+	peer.handshake.mutex.Unlock()
+
+	return peer.SendHandshakeInitiation(false)
+}
+
 func (peer *Peer) SendHandshakeResponse() error {
 	peer.handshake.mutex.Lock()
 	peer.handshake.lastSentHandshake = time.Now()

--- a/device/send.go
+++ b/device/send.go
@@ -16,6 +16,7 @@ import (
 	"golang.org/x/crypto/chacha20poly1305"
 	"golang.org/x/net/ipv4"
 	"golang.org/x/net/ipv6"
+
 	"golang.zx2c4.com/wireguard/conn"
 	"golang.zx2c4.com/wireguard/tun"
 )
@@ -115,6 +116,12 @@ func (peer *Peer) SendHandshakeInitiation(isRetry bool) error {
 	peer.handshake.lastSentHandshake = time.Now()
 	peer.handshake.mutex.Unlock()
 
+	return peer.sendHandshakeInitiation()
+}
+
+// sendHandshakeInitiation transmits the initiation; the caller owns the
+// RekeyTimeout throttle and lastSentHandshake.
+func (peer *Peer) sendHandshakeInitiation() error {
 	peer.device.log.Verbosef("%v - Sending handshake initiation", peer)
 
 	msg, err := peer.device.CreateMessageInitiation(peer)
@@ -139,14 +146,17 @@ func (peer *Peer) SendHandshakeInitiation(isRetry bool) error {
 	return err
 }
 
-// SendImmediateHandshakeInitiation resets the RekeyTimeout throttle and sends a
-// handshake initiation right away. Used when the endpoint just changed.
-func (peer *Peer) SendImmediateHandshakeInitiation() error {
+// SendHandshakeInitiationOnEndpointChange starts a fresh handshake from the new
+// endpoint, skipping the RekeyTimeout throttle since any in-flight retry is
+// timed against the old address.
+func (peer *Peer) SendHandshakeInitiationOnEndpointChange() error {
+	peer.timers.handshakeAttempts.Store(0)
+
 	peer.handshake.mutex.Lock()
-	peer.handshake.lastSentHandshake = time.Now().Add(-(RekeyTimeout + time.Second))
+	peer.handshake.lastSentHandshake = time.Now()
 	peer.handshake.mutex.Unlock()
 
-	return peer.SendHandshakeInitiation(false)
+	return peer.sendHandshakeInitiation()
 }
 
 func (peer *Peer) SendHandshakeResponse() error {

--- a/device/send.go
+++ b/device/send.go
@@ -146,6 +146,15 @@ func (peer *Peer) sendHandshakeInitiation() error {
 	return err
 }
 
+// needsHandshake reports whether the peer lacks a usable session, i.e. a new
+// handshake is required before traffic can flow.
+func (peer *Peer) needsHandshake() bool {
+	keypair := peer.keypairs.Current()
+	return keypair == nil ||
+		keypair.sendNonce.Load() >= RejectAfterMessages ||
+		time.Since(keypair.created) >= RejectAfterTime
+}
+
 // SendHandshakeInitiationOnEndpointChange starts a fresh handshake from the new
 // endpoint, skipping the RekeyTimeout throttle since any in-flight retry is
 // timed against the old address.

--- a/device/uapi.go
+++ b/device/uapi.go
@@ -268,7 +268,7 @@ func (peer *ipcSetPeer) handlePostConfig() {
 		if peer.pkaOn {
 			peer.SendKeepalive()
 		}
-		if peer.endpointChanged {
+		if peer.endpointChanged && peer.needsHandshake() {
 			peer.SendHandshakeInitiationOnEndpointChange()
 		}
 		peer.SendStagedPackets()

--- a/device/uapi.go
+++ b/device/uapi.go
@@ -253,7 +253,7 @@ type ipcSetPeer struct {
 	dummy           bool // dummy reports whether this peer is a temporary, placeholder peer
 	created         bool // new reports whether this is a newly created peer
 	pkaOn           bool // pkaOn reports whether the peer had the persistent keepalive turn on
-	endpointChanged bool // endpointChanged reports whether the endpoint address changed
+	endpointChanged bool // the endpoint address changed
 }
 
 func (peer *ipcSetPeer) handlePostConfig() {
@@ -269,7 +269,7 @@ func (peer *ipcSetPeer) handlePostConfig() {
 			peer.SendKeepalive()
 		}
 		if peer.endpointChanged {
-			peer.SendImmediateHandshakeInitiation()
+			peer.SendHandshakeInitiationOnEndpointChange()
 		}
 		peer.SendStagedPackets()
 	}
@@ -348,8 +348,7 @@ func (device *Device) handlePeerLine(peer *ipcSetPeer, key, value string) error 
 			return ipcErrorf(ipc.IpcErrorInvalid, "failed to set endpoint %v: %w", value, err)
 		}
 		peer.endpoint.Lock()
-		// Trigger an immediate handshake only when an existing endpoint changes;
-		// the initial assignment is left to the normal SendStagedPackets path.
+		// Only an actual change of an existing endpoint triggers a handshake.
 		if peer.endpoint.val != nil && peer.endpoint.val.DstToString() != endpoint.DstToString() {
 			peer.endpointChanged = true
 		}

--- a/device/uapi.go
+++ b/device/uapi.go
@@ -249,10 +249,11 @@ func (device *Device) handleDeviceLine(key, value string) error {
 
 // An ipcSetPeer is the current state of an IPC set operation on a peer.
 type ipcSetPeer struct {
-	*Peer        // Peer is the current peer being operated on
-	dummy   bool // dummy reports whether this peer is a temporary, placeholder peer
-	created bool // new reports whether this is a newly created peer
-	pkaOn   bool // pkaOn reports whether the peer had the persistent keepalive turn on
+	*Peer                // Peer is the current peer being operated on
+	dummy           bool // dummy reports whether this peer is a temporary, placeholder peer
+	created         bool // new reports whether this is a newly created peer
+	pkaOn           bool // pkaOn reports whether the peer had the persistent keepalive turn on
+	endpointChanged bool // endpointChanged reports whether the endpoint address changed
 }
 
 func (peer *ipcSetPeer) handlePostConfig() {
@@ -266,6 +267,9 @@ func (peer *ipcSetPeer) handlePostConfig() {
 		peer.Start()
 		if peer.pkaOn {
 			peer.SendKeepalive()
+		}
+		if peer.endpointChanged {
+			peer.SendImmediateHandshakeInitiation()
 		}
 		peer.SendStagedPackets()
 	}
@@ -344,8 +348,13 @@ func (device *Device) handlePeerLine(peer *ipcSetPeer, key, value string) error 
 			return ipcErrorf(ipc.IpcErrorInvalid, "failed to set endpoint %v: %w", value, err)
 		}
 		peer.endpoint.Lock()
-		defer peer.endpoint.Unlock()
+		// Trigger an immediate handshake only when an existing endpoint changes;
+		// the initial assignment is left to the normal SendStagedPackets path.
+		if peer.endpoint.val != nil && peer.endpoint.val.DstToString() != endpoint.DstToString() {
+			peer.endpointChanged = true
+		}
 		peer.endpoint.val = endpoint
+		peer.endpoint.Unlock()
 
 	case "persistent_keepalive_interval":
 		device.log.Verbosef("%v - UAPI: Updating persistent keepalive interval", peer.Peer)


### PR DESCRIPTION
When a peer's endpoint is changed via UAPI to a new, non-nil address (e.g. an external signal learned a now-reachable address) while a handshake retry cycle is still mid-RekeyTimeout, force a handshake initiation right away instead of waiting out the remaining ~5s.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added immediate handshake initiation when a peer's endpoint changes to re-establish connectivity without delay.

* **Bug Fixes**
  * Endpoint-change detection improved to trigger handshakes only on real destination changes, avoiding unnecessary network exchanges.
  * Handshake attempts are reset for endpoint changes so the reconnect proceeds promptly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->